### PR TITLE
fix: utf-8 encoding for reading txt files

### DIFF
--- a/ko_lm_dataformat/reader.py
+++ b/ko_lm_dataformat/reader.py
@@ -91,7 +91,7 @@ class Reader:
                 print(f"Skipping {f} as streaming for that filetype is not implemented")
 
     def read_txt(self, file):
-        with open(file, "r") as fh:
+        with open(file, "r", encoding="utf-8") as fh:
             yield fh.read()
 
     def read_zip(self, file):


### PR DESCRIPTION
## Description

For file encodings, try to read files using `utf-8` 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
