### PR TITLE
feat: add func `set_sentence_splitter`

### DIFF
--- a/ko_lm_dataformat/archive.py
+++ b/ko_lm_dataformat/archive.py
@@ -84,6 +84,9 @@ class Archive:
 
         self.commit_cnt += 1
 
+    def set_sentence_splitter(self, sentence_splitter: SentenceSplitterBase):
+        self.sentence_splitter = sentence_splitter
+
 
 class DatArchive:
     def __init__(self, out_dir: str, sentence_splitter: Optional[SentenceSplitterBase] = None, level: int = 3):


### PR DESCRIPTION
## Description

Setting a sentence_splitter for archive would help ppl at the time when archive is declared and when the sentence splitter needs to be changed

## Related Issue

[Issue 10](https://github.com/monologg/ko_lm_dataformat/issues/10)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
