### PR TITLE
Feat: add func `set_chunk_name` to avoid permission issues  

### DIFF
--- a/ko_lm_dataformat/archive.py
+++ b/ko_lm_dataformat/archive.py
@@ -43,9 +43,10 @@ class Archive:
 
     def set_chunk_name(self):
         # check whether the incomplete chunks exist
-        init_path = os.path.join(self.out_dir, CURRENT_CHUNK_INCOMPLETE + "*")
-        chunk_list = glob(init_path)
-        sorted(chunk_list)
+        chunk_list = glob(os.path.join(self.out_dir, CURRENT_CHUNK_INCOMPLETE + "*"))
+        # sort the names of chunks by numerical order
+        chunk_list = sorted(chunk_list, key=lambda name: int(name.split("_")[-1]))
+        # give a unique name of the current chunk
         chunk_num = 0
         if chunk_list and chunk_list[-1]:
             chunk_num = int(chunk_list[-1].split("_")[-1]) + 1

--- a/ko_lm_dataformat/archive.py
+++ b/ko_lm_dataformat/archive.py
@@ -43,7 +43,7 @@ class Archive:
 
     def set_chunk_name(self):
         # check whether the incomplete chunks exist
-        chunk_list = glob(os.path.join(self.out_dir, CURRENT_CHUNK_INCOMPLETE + "*"))
+        chunk_list = glob(os.path.join(self.out_dir, CURRENT_CHUNK_INCOMPLETE + "_*"))
         # sort the names of chunks by numerical order
         chunk_list = sorted(chunk_list, key=lambda name: int(name.split("_")[-1]))
         # give a unique name of the current chunk

--- a/ko_lm_dataformat/archive.py
+++ b/ko_lm_dataformat/archive.py
@@ -1,10 +1,10 @@
 import os
 import time
+from glob import glob
 from typing import List, Optional, Union
 
 import ujson as json
 import zstandard
-from glob import glob
 
 from .sentence_cleaner import clean_sentence
 from .sentence_splitter import SentenceSplitterBase
@@ -52,9 +52,7 @@ class Archive:
 
         return os.path.join(self.out_dir, f"{CURRENT_CHUNK_INCOMPLETE}_{chunk_num}")
 
-    def add_data(
-        self, data: Union[str, List[str]], meta=None, split_sent: bool = False, clean_sent: bool = False
-    ):
+    def add_data(self, data: Union[str, List[str]], meta=None, split_sent: bool = False, clean_sent: bool = False):
         """
         Args:
             data (Union[str, List[str]]):

--- a/ko_lm_dataformat/sentence_splitter.py
+++ b/ko_lm_dataformat/sentence_splitter.py
@@ -14,7 +14,7 @@ class SentenceSplitterBase:
     def __init__(self):
         self.splitter = None
 
-    def split(self, document: str) -> List[str]:
+    def split(self, document: str, clean_sent: bool) -> List[str]:
         raise NotImplementedError
 
 
@@ -32,10 +32,7 @@ class KssV1SentenceSplitter(SentenceSplitterBase):
             )
 
     def split(self, document: str, clean_sent: bool = False) -> List[str]:
-        if not clean_sent:
-            return self.splitter.split_sentences(document)
-        else:
-            cleaned_output = []
-            for sent in self.splitter.split_sentences(document):
-                cleaned_output.append(clean_sentence(sent))
-            return cleaned_output
+        sentences = self.splitter.split_sentences(document)
+        if clean_sent:
+            sentences = [clean_sentence(sent) for sent in sentences]
+        return sentences


### PR DESCRIPTION
## Description

Previous might have an issue with permission if two or more archive obj declared pointing the same dir.

## Related Issue

[issue#10](https://github.com/monologg/ko_lm_dataformat/issues/10#issue-940350885)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
