### PR TITLE
Fix test failures on Windows by closing file handles and encoding

### DIFF
--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -14,6 +14,11 @@ def test_kowiki_archive():
     with open(get_tests_dir(append_path="assets/kowiki_sample.txt"), "r", encoding="utf-8") as f:
         for line in f:
             archive.add_data(line.strip())
+    
+    # close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
+    
     shutil.rmtree(TMP_DIR_NAME)
 
 
@@ -23,6 +28,10 @@ def test_archive_json_data():
     with open(get_tests_dir(append_path="assets/sample.json"), "r", encoding="utf-8") as f:
         data = json.load(f)
     archive.add_data(data)
+
+    # close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
 
     shutil.rmtree(TMP_DIR_NAME)
 
@@ -34,6 +43,11 @@ def test_archive_json_data_is_same():
         orig_data = json.load(f)
     archive.add_data(orig_data)
     archive.commit()
+    
+    # Close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
+    
     reader = kldf.Reader(TMP_DIR_NAME)
     kldf_data = list(reader.stream_data())
     assert kldf_data[0] == orig_data
@@ -42,9 +56,14 @@ def test_archive_json_data_is_same():
 def test_kor_str_is_same():
     remove_tmp_dir()
     archive = kldf.Archive(TMP_DIR_NAME)
-    text = open(get_tests_dir(append_path="assets/kowiki_sample.txt"), "r", encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/kowiki_sample.txt"), "r", encoding="utf-8") as f:
+        text = f.read()
     archive.add_data(text)
     archive.commit()
+
+    # Close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
 
     reader = kldf.Reader(TMP_DIR_NAME)
     data = list(reader.stream_data())
@@ -58,4 +77,9 @@ def test_archive_kss_sent_split():
     with open(get_tests_dir(append_path="assets/kowiki_sample.txt"), "r", encoding="utf-8") as f:
         for line in f:
             archive.add_data(line.strip(), split_sent=True, clean_sent=False)
+    
+    # Close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
+    
     shutil.rmtree(TMP_DIR_NAME)

--- a/tests/test_simple_examples.py
+++ b/tests/test_simple_examples.py
@@ -15,7 +15,7 @@ def sha256str(s):
 def test_dat():
     remove_tmp_dir()
     archive = kldf.DatArchive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
     archive.add_data(blns)
     archive.add_data("testing 123")
     archive.add_data(blns)
@@ -36,7 +36,7 @@ def test_dat():
 def test_json():
     remove_tmp_dir()
     archive = kldf.JSONArchive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
     archive.add_data(blns)
     archive.add_data("testing 123")
     archive.add_data(blns)
@@ -57,7 +57,7 @@ def test_json():
 def test_jsonl():
     remove_tmp_dir()
     archive = kldf.Archive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
     archive.add_data(blns)
     archive.add_data("testing 123", meta={"testing": 123})
     archive.add_data(blns, meta={"testing2": 456, "testing": ["a", "b"]})
@@ -91,7 +91,7 @@ def test_naughty_string():
 def test_jsonl_sentences():
     remove_tmp_dir()
     archive = kldf.Archive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
     archive.add_data(blns)
     archive.add_data(["testing 123", "testing 345"], meta={"testing": 123})
     archive.add_data(blns, meta={"testing2": 456, "testing": ["a", "b"]})
@@ -110,7 +110,7 @@ def test_jsonl_sentences():
 
 
 def test_jsonl_tar():
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.jsonl.zst.tar"))
 
     data = list(reader.stream_data(get_meta=True, autojoin_sentences=True, sent_joiner="\n"))
@@ -128,7 +128,7 @@ def test_jsonl_tar():
 
 def test_txt_read():
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.txt"))
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
 
     data = list(reader.stream_data(get_meta=False))
 
@@ -138,7 +138,7 @@ def test_txt_read():
 
 def test_zip_read():
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.txt.zip"))
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
 
     data = list(reader.stream_data(get_meta=False))
 
@@ -148,7 +148,7 @@ def test_zip_read():
 
 def test_tgz_read():
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.txt.tar.gz"))
-    blns = open(get_tests_dir(append_path="assets/blns.txt")).read()
+    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
 
     data = list(reader.stream_data(get_meta=False))
 

--- a/tests/test_simple_examples.py
+++ b/tests/test_simple_examples.py
@@ -67,6 +67,10 @@ def test_jsonl():
     archive.add_data("testing 123456789")
     archive.commit()
 
+    # close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
+
     reader = kldf.Reader(TMP_DIR_NAME)
 
     data = list(reader.stream_data(get_meta=True))
@@ -85,6 +89,10 @@ def test_naughty_string():
     archive.add_data(naughty_text, clean_sent=True)
     archive.commit()
 
+    # close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
+
     reader = kldf.Reader(TMP_DIR_NAME)
 
     data = list(reader.stream_data())
@@ -101,6 +109,10 @@ def test_jsonl_sentences():
     archive.add_data(blns, meta={"testing2": 456, "testing": ["a", "b"]})
     archive.add_data("testing 123456789")
     archive.commit()
+
+    # close the archive's file handles to avoid Windows permission issues
+    archive.compressor.close()
+    archive.fh.close()
 
     reader = kldf.Reader(TMP_DIR_NAME)
 

--- a/tests/test_simple_examples.py
+++ b/tests/test_simple_examples.py
@@ -15,7 +15,8 @@ def sha256str(s):
 def test_dat():
     remove_tmp_dir()
     archive = kldf.DatArchive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
     archive.add_data(blns)
     archive.add_data("testing 123")
     archive.add_data(blns)
@@ -36,7 +37,8 @@ def test_dat():
 def test_json():
     remove_tmp_dir()
     archive = kldf.JSONArchive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
     archive.add_data(blns)
     archive.add_data("testing 123")
     archive.add_data(blns)
@@ -57,7 +59,8 @@ def test_json():
 def test_jsonl():
     remove_tmp_dir()
     archive = kldf.Archive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
     archive.add_data(blns)
     archive.add_data("testing 123", meta={"testing": 123})
     archive.add_data(blns, meta={"testing2": 456, "testing": ["a", "b"]})
@@ -91,7 +94,8 @@ def test_naughty_string():
 def test_jsonl_sentences():
     remove_tmp_dir()
     archive = kldf.Archive(TMP_DIR_NAME)
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
     archive.add_data(blns)
     archive.add_data(["testing 123", "testing 345"], meta={"testing": 123})
     archive.add_data(blns, meta={"testing2": 456, "testing": ["a", "b"]})
@@ -110,7 +114,8 @@ def test_jsonl_sentences():
 
 
 def test_jsonl_tar():
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.jsonl.zst.tar"))
 
     data = list(reader.stream_data(get_meta=True, autojoin_sentences=True, sent_joiner="\n"))
@@ -128,7 +133,8 @@ def test_jsonl_tar():
 
 def test_txt_read():
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.txt"))
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
 
     data = list(reader.stream_data(get_meta=False))
 
@@ -138,7 +144,8 @@ def test_txt_read():
 
 def test_zip_read():
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.txt.zip"))
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
 
     data = list(reader.stream_data(get_meta=False))
 
@@ -148,7 +155,8 @@ def test_zip_read():
 
 def test_tgz_read():
     reader = kldf.Reader(get_tests_dir(append_path="assets/blns.txt.tar.gz"))
-    blns = open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8").read()
+    with open(get_tests_dir(append_path="assets/blns.txt"), encoding="utf-8") as f:
+        blns = f.read()
 
     data = list(reader.stream_data(get_meta=False))
 
@@ -157,15 +165,16 @@ def test_tgz_read():
 
 
 def test_tarfile_reader():
-    rdr = kldf.tarfile_reader(open(get_tests_dir(append_path="assets/testtarfile.tar"), "rb"), streaming=True)
+    with open(get_tests_dir(append_path="assets/testtarfile.tar"), "rb") as f:
+        rdr = kldf.tarfile_reader(f, streaming=True)
 
-    hashes = map(lambda doc: sha256str(doc.read()), rdr)
+        hashes = map(lambda doc: sha256str(doc.read()), rdr)
 
-    expected = [
-        "782588d891b1a836fcbd0bcd43227f83bf066d90245dd91d061f1b2c0e72fc9d",
-        "dc666c65cd421c688ed8542223c24d9e4a2e5276944f1e7cc296d43a57245498",
-        "c38af4ad8a9b901ea75d7cf60d452a233949f9e88b5fea04f80acde29d513d3e",
-        "fb3ecc0ad0b851dd3e9f0955805530b4946080f6e2a8e6aa0f67ba8209c2f779",
-    ]
+        expected = [
+            "782588d891b1a836fcbd0bcd43227f83bf066d90245dd91d061f1b2c0e72fc9d",
+            "dc666c65cd421c688ed8542223c24d9e4a2e5276944f1e7cc296d43a57245498",
+            "c38af4ad8a9b901ea75d7cf60d452a233949f9e88b5fea04f80acde29d513d3e",
+            "fb3ecc0ad0b851dd3e9f0955805530b4946080f6e2a8e6aa0f67ba8209c2f779",
+        ]
 
-    assert all(map(lambda x: x[0] == x[1], zip(hashes, expected)))
+        assert all(map(lambda x: x[0] == x[1], zip(hashes, expected)))


### PR DESCRIPTION
## Description

When running the test suite on Windows, some tests failed with PermissionError because temporary files were still open when the tests attempted to delete them. This problem don't happen in unix systems. 

This PR improves test portability by:

- Explicitly closing archive file handles (archive.compressor and archive.fh) after use.
- Updating file reads to use context managers (with open(...)) to ensure proper cleanup.
- For text files, explicitly setting encoding="utf-8" to fix platform-specific encoding issues.

These changes ensure the tests pass consistently on Windows, Linux, and macOS.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
